### PR TITLE
Cleanp arch/i386/descriptors.c

### DIFF
--- a/kernel/arch/i386/descriptors.c
+++ b/kernel/arch/i386/descriptors.c
@@ -308,7 +308,7 @@ struct gdt_entry {
   uint32_t direction_conforming : 1;
   uint32_t executable : 1;
   uint32_t type : 1;
-  uint32_t privilege : 2;
+  uint32_t DPL : 2;
   uint32_t present : 1;
 
   uint32_t limit_last_4 : 4;
@@ -409,7 +409,7 @@ typedef struct idt_ptr idt_ptr;
 static void set_gdt_entry(gdt_entry_t *entry, uint32_t base, uint32_t limit,
                           bool accessed, bool read_write,
                           bool direction_conforming, bool executable, bool type,
-                          uint8_t privilege, bool present, bool size,
+                          uint8_t DPL, bool present, bool size,
                           bool granularity);
 
 static void set_tss_descriptor(tss_descriptor_t *descriptor, uint32_t base,
@@ -427,7 +427,7 @@ idt_entry_t idt_entries[NUMBER_IDT_ENTRIES];
 static void set_gdt_entry(gdt_entry_t *entry, uint32_t base, uint32_t limit,
                           bool accessed, bool read_write,
                           bool direction_conforming, bool executable, bool type,
-                          uint8_t privilege, bool present, bool size,
+                          uint8_t DPL, bool present, bool size,
                           bool granularity) {
   entry->limit_first_16       = limit & 0xFFFF;
   entry->base_first_24        = base & 0xFFFFFF;
@@ -436,7 +436,7 @@ static void set_gdt_entry(gdt_entry_t *entry, uint32_t base, uint32_t limit,
   entry->direction_conforming = direction_conforming;
   entry->executable           = executable;
   entry->type                 = type;
-  entry->privilege            = privilege;
+  entry->DPL                  = DPL;
   entry->present              = present;
   entry->limit_last_4         = (limit >> (20 - 4)) & 0x0F;
   entry->always_0             = 0;

--- a/kernel/arch/i386/descriptors.c
+++ b/kernel/arch/i386/descriptors.c
@@ -10,6 +10,25 @@
 #define NUMBER_IDT_ENTRIES 256
 #define NUMBER_GDT_ENTRIES 6
 
+#define DPL_KERNEL 0
+#define DPL_USER   3
+
+#define KERNEL_CODE_INDEX 1
+#define KERNEL_DATA_INDEX 2
+#define USER_CODE_INDEX   3
+#define USER_DATA_INDEX   4
+
+#define SELECTOR_SHIFT_AMOUNT 3
+
+#define KERNEL_CODE_SELECTOR \
+  ((KERNEL_CODE_INDEX << SELECTOR_SHIFT_AMOUNT) | DPL_KERNEL)
+#define KERNEL_DATA_SELECTOR \
+  ((KERNEL_DATA_INDEX << SELECTOR_SHIFT_AMOUNT) | DPL_KERNEL)
+#define USER_CODE_SELECTOR \
+  ((USER_CODE_INDEX << SELECTOR_SHIFT_AMOUNT) | DPL_USER)
+#define USER_DATA_SELECTOR \
+  ((USER_DATA_INDEX << SELECTOR_SHIFT_AMOUNT) | DPL_USER)
+
 // declare the interrupt service routines
 extern void isr0();
 extern void isr1();
@@ -278,21 +297,30 @@ extern uint8_t syscall_stack[];
 
 static void irq_init(void);
 void watch(void);
-static void set_idt_entry(size_t index, uint32_t offset, uint16_t selector,
-                          uint8_t flags);
 
 struct gdt_entry {
-  uint16_t limit_first_16;
-  uint16_t base_first_16;
-  uint8_t base_middle_8;
-  uint8_t access_byte;
-  uint8_t limit_last_4_flags;
-  uint8_t base_last_8;
-} __attribute__((packed));
-typedef struct gdt_entry gdt_entry;
+  uint32_t limit_first_16 : 16;
+  uint32_t base_first_24 : 24;
 
-static gdt_entry create_gdt_entry(uint32_t base, uint32_t limit,
-                                  uint8_t access_byte, uint8_t flags);
+  // access byte
+  uint32_t accessed : 1;
+  uint32_t read_write : 1;
+  uint32_t direction_conforming : 1;
+  uint32_t executable : 1;
+  uint32_t type : 1;
+  uint32_t privilege : 2;
+  uint32_t present : 1;
+
+  uint32_t limit_last_4 : 4;
+
+  // flags
+  uint32_t always_0 : 2;
+  uint32_t size : 1;
+  uint32_t granularity : 1;
+
+  uint32_t base_last_8 : 8;
+} __attribute__((packed));
+typedef struct gdt_entry gdt_entry_t;
 
 struct gdt_ptr {
   uint16_t size;
@@ -358,19 +386,19 @@ struct tss_descriptor {
   uint32_t granularity : 1;
   uint32_t base_last_8 : 8;
 } __attribute__((packed));
-typedef struct tss_descriptor tss_descriptor;
+typedef struct tss_descriptor tss_descriptor_t;
 
 struct idt_entry {
-  uint16_t offset_first_16;
-  uint16_t selector;
-  uint8_t reserved;
-  uint8_t flags;
-  uint16_t offset_last_16;
+  uint32_t offset_first_16 : 16;
+  uint32_t selector : 16;
+  uint32_t always_0 : 8;
+  uint32_t type : 4;
+  uint32_t storage_segment : 1;
+  uint32_t DPL : 2;
+  uint32_t present : 1;
+  uint32_t offset_last_16 : 16;
 } __attribute__((packed));
-typedef struct idt_entry idt_entry;
-
-static idt_entry create_idt_entry(uint32_t offset, uint16_t selector,
-                                  uint8_t flags);
+typedef struct idt_entry idt_entry_t;
 
 struct idt_ptr {
   uint16_t limit;
@@ -378,67 +406,89 @@ struct idt_ptr {
 } __attribute__((packed));
 typedef struct idt_ptr idt_ptr;
 
-gdt_entry gdt_entries[NUMBER_GDT_ENTRIES];
+static void set_gdt_entry(gdt_entry_t *entry, uint32_t base, uint32_t limit,
+                          bool accessed, bool read_write,
+                          bool direction_conforming, bool executable, bool type,
+                          uint8_t privilege, bool present, bool size,
+                          bool granularity);
+
+static void set_tss_descriptor(tss_descriptor_t *descriptor, uint32_t base,
+                               uint32_t limit, bool busy, uint8_t DPL,
+                               bool present, bool granularity);
+
+static void set_idt_entry(idt_entry_t *entry, uint32_t offset,
+                          uint16_t selector, uint8_t type, bool storage_segment,
+                          uint8_t DPL, bool present);
+
+gdt_entry_t gdt_entries[NUMBER_GDT_ENTRIES];
 tss_entry_t tss_entry;
-idt_entry idt_entries[NUMBER_IDT_ENTRIES];
+idt_entry_t idt_entries[NUMBER_IDT_ENTRIES];
 
-static gdt_entry create_gdt_entry(uint32_t base, uint32_t limit,
-                                  uint8_t access_byte, uint8_t flags) {
-  gdt_entry entry_to_fill;
-
-  entry_to_fill.limit_first_16     = limit & 0xFFFF;
-  entry_to_fill.base_first_16      = base & 0xFFFF;
-  entry_to_fill.base_middle_8      = (base >> 16) & 0xFF;
-  entry_to_fill.access_byte        = access_byte;
-  entry_to_fill.limit_last_4_flags = (limit >> 16) & 0x0F;
-  entry_to_fill.limit_last_4_flags |= flags & 0xF0;
-  entry_to_fill.base_last_8 = (base >> 24) & 0xFF;
-
-  return entry_to_fill;
+static void set_gdt_entry(gdt_entry_t *entry, uint32_t base, uint32_t limit,
+                          bool accessed, bool read_write,
+                          bool direction_conforming, bool executable, bool type,
+                          uint8_t privilege, bool present, bool size,
+                          bool granularity) {
+  entry->limit_first_16       = limit & 0xFFFF;
+  entry->base_first_24        = base & 0xFFFFFF;
+  entry->accessed             = accessed;
+  entry->read_write           = read_write;
+  entry->direction_conforming = direction_conforming;
+  entry->executable           = executable;
+  entry->type                 = type;
+  entry->privilege            = privilege;
+  entry->present              = present;
+  entry->limit_last_4         = (limit >> (20 - 4)) & 0x0F;
+  entry->always_0             = 0;
+  entry->size                 = size;
+  entry->granularity          = granularity;
+  entry->base_last_8          = (base >> (32 - 8)) & 0xFF;
 }
 
-static gdt_entry create_tss_descriptor(uint32_t base, uint32_t limit, bool busy,
-                                       int DPL, int present, bool granularity) {
-  tss_descriptor descriptor_to_fill;
-
-  descriptor_to_fill.limit_first_16 = limit & 0xFFFF;
-  descriptor_to_fill.base_first_24  = base & 0xFFFFFF;
-  descriptor_to_fill.always_1       = 1;
-  descriptor_to_fill.busy           = busy;
-  descriptor_to_fill.always_0       = 0;
-  descriptor_to_fill.always_1_2     = 1;
-  descriptor_to_fill.always_0_2     = 0;
-  descriptor_to_fill.DPL            = DPL;
-  descriptor_to_fill.present        = present;
-  descriptor_to_fill.limit_last_4   = limit >> (32 - 4);
-  descriptor_to_fill.always_0_3     = 0;
-  descriptor_to_fill.granularity    = granularity;
-  descriptor_to_fill.base_last_8    = (base >> 24) & 0xFF;
-
-  // a bit hacky, but not as much as intel :P
-  return *(gdt_entry *)&descriptor_to_fill;
+static void set_tss_descriptor(tss_descriptor_t *descriptor, uint32_t base,
+                               uint32_t limit, bool busy, uint8_t DPL,
+                               bool present, bool granularity) {
+  descriptor->limit_first_16 = limit & 0xFFFF;
+  descriptor->base_first_24  = base & 0xFFFFFF;
+  descriptor->always_1       = 1;
+  descriptor->busy           = busy;
+  descriptor->always_0       = 0;
+  descriptor->always_1_2     = 1;
+  descriptor->always_0_2     = 0;
+  descriptor->DPL            = DPL;
+  descriptor->present        = present;
+  descriptor->limit_last_4   = limit >> (32 - 4);
+  descriptor->always_0_3     = 0;
+  descriptor->granularity    = granularity;
+  descriptor->base_last_8    = (base >> (32 - 8)) & 0xFF;
 }
 
 void gdt_init(void) {
   // fill the entries
-  gdt_entries[0] = create_gdt_entry(0, 0, 0, 0);                // null entry
-  gdt_entries[1] = create_gdt_entry(0, 0xFFFFFFFF, 0x9A, 0xCF); // kernel code
-  gdt_entries[2] = create_gdt_entry(0, 0xFFFFFFFF, 0x92, 0xCF); // kernel data
-  gdt_entries[3] = create_gdt_entry(0, 0xFFFFFFFF, 0xFA, 0xCF); // user code
-  gdt_entries[4] = create_gdt_entry(0, 0xFFFFFFFF, 0xF2, 0xCF); // user data
-  gdt_entries[5] = create_tss_descriptor(
-      (uint32_t)&tss_entry, sizeof(tss_entry_t), 0, 3, 1, 0); // TSS
+  set_gdt_entry(&gdt_entries[0], 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0); // null entry
+  set_gdt_entry(&gdt_entries[1], 0, 0xFFFFFFFF, 0, 1, 0, 1, 1, DPL_KERNEL, 1, 1,
+                1); // kernel code
+  set_gdt_entry(&gdt_entries[2], 0, 0xFFFFFFFF, 0, 1, 0, 0, 1, DPL_KERNEL, 1, 1,
+                1); // kernel data
+  set_gdt_entry(&gdt_entries[3], 0, 0xFFFFFFFF, 0, 1, 0, 1, 1, DPL_USER, 1, 1,
+                1); // user code
+  set_gdt_entry(&gdt_entries[4], 0, 0xFFFFFFFF, 0, 1, 0, 0, 1, DPL_USER, 1, 1,
+                1); // user data
+  set_tss_descriptor((tss_descriptor_t *)&gdt_entries[5], (uint32_t)&tss_entry,
+                     sizeof(tss_entry_t), 0, DPL_USER, 1,
+                     0); // TSS
 }
 
 void tss_init(void) {
-  tss_entry.ss0  = 0x10;                     // kernel data
+  tss_entry.ss0  = KERNEL_DATA_SELECTOR;     // kernel data
   tss_entry.esp0 = (uint32_t)&syscall_stack; // stack pointer for syscalls
   tss_entry.iopb_offset = sizeof(tss_entry_t);
 }
 
 void enter_pmode(void) {
   gdt_ptr ptr_to_gdt;
-  ptr_to_gdt.size   = sizeof(gdt_entry) * NUMBER_GDT_ENTRIES - 1;
+  ptr_to_gdt.size   = sizeof(gdt_entry_t) * NUMBER_GDT_ENTRIES - 1;
   ptr_to_gdt.offset = (uint32_t)&gdt_entries;
 
   asm("cli"); // sti only after loading idt to avoid triple faut
@@ -447,297 +497,540 @@ void enter_pmode(void) {
   set_pmode();
 }
 
-static idt_entry create_idt_entry(uint32_t offset, uint16_t selector,
-                                  uint8_t flags) {
-  idt_entry entry_to_fill;
-
-  entry_to_fill.offset_first_16 = offset & 0xFFFF;
-  entry_to_fill.selector        = selector;
-  entry_to_fill.reserved        = 0;
-  entry_to_fill.flags           = flags;
-  entry_to_fill.offset_last_16  = (offset >> 16) & 0xFFFF;
-
-  return entry_to_fill;
-}
-
-static void set_idt_entry(size_t index, uint32_t offset, uint16_t selector,
-                          uint8_t flags) {
-  idt_entry temp_entry = create_idt_entry(offset, selector, flags);
-  idt_entries[index]   = temp_entry;
+static void set_idt_entry(idt_entry_t *entry, uint32_t offset,
+                          uint16_t selector, uint8_t type, bool storage_segment,
+                          uint8_t DPL, bool present) {
+  entry->offset_first_16 = offset & 0xFFFF;
+  entry->selector        = selector;
+  entry->always_0        = 0;
+  entry->type            = type;
+  entry->storage_segment = storage_segment;
+  entry->DPL             = DPL;
+  entry->present         = present;
+  entry->offset_last_16  = (offset >> (32 - 16)) & 0xFFFF;
 }
 
 void idt_init(void) {
   idt_ptr ptr_to_idt;
-  ptr_to_idt.limit = (uint16_t)sizeof(idt_entry) * NUMBER_IDT_ENTRIES - 1;
+  ptr_to_idt.limit = (uint16_t)sizeof(idt_entry_t) * NUMBER_IDT_ENTRIES - 1;
   ptr_to_idt.base  = (uint32_t)&idt_entries;
 
   // set all idt gates
-  // selector: kernel code in ring 0 (row 2) so 0x08
-  // flags: gate type 0b1111 for 32bit interrupt, ring 0 DPL and not unused so
-  // 0x8e
-
-  // for the 0x80 syscall gate, use a trap instead and ring 3 DPL
-
-  set_idt_entry(0, (uint32_t)isr0, 0x08, 0x8e);
-  set_idt_entry(1, (uint32_t)isr1, 0x08, 0x8e);
-  set_idt_entry(2, (uint32_t)isr2, 0x08, 0x8e);
-  set_idt_entry(3, (uint32_t)isr3, 0x08, 0x8e);
-  set_idt_entry(4, (uint32_t)isr4, 0x08, 0x8e);
-  set_idt_entry(5, (uint32_t)isr5, 0x08, 0x8e);
-  set_idt_entry(6, (uint32_t)isr6, 0x08, 0x8e);
-  set_idt_entry(7, (uint32_t)isr7, 0x08, 0x8e);
-  set_idt_entry(8, (uint32_t)isr8, 0x08, 0x8e);
-  set_idt_entry(9, (uint32_t)isr9, 0x08, 0x8e);
-  set_idt_entry(10, (uint32_t)isr10, 0x08, 0x8e);
-  set_idt_entry(11, (uint32_t)isr11, 0x08, 0x8e);
-  set_idt_entry(12, (uint32_t)isr12, 0x08, 0x8e);
-  set_idt_entry(13, (uint32_t)isr13, 0x08, 0x8e);
-  set_idt_entry(14, (uint32_t)isr14, 0x08, 0x8e);
-  set_idt_entry(15, (uint32_t)isr15, 0x08, 0x8e);
-  set_idt_entry(16, (uint32_t)isr16, 0x08, 0x8e);
-  set_idt_entry(17, (uint32_t)isr17, 0x08, 0x8e);
-  set_idt_entry(18, (uint32_t)isr18, 0x08, 0x8e);
-  set_idt_entry(19, (uint32_t)isr19, 0x08, 0x8e);
-  set_idt_entry(20, (uint32_t)isr20, 0x08, 0x8e);
-  set_idt_entry(21, (uint32_t)isr21, 0x08, 0x8e);
-  set_idt_entry(22, (uint32_t)isr22, 0x08, 0x8e);
-  set_idt_entry(23, (uint32_t)isr23, 0x08, 0x8e);
-  set_idt_entry(24, (uint32_t)isr24, 0x08, 0x8e);
-  set_idt_entry(25, (uint32_t)isr25, 0x08, 0x8e);
-  set_idt_entry(26, (uint32_t)isr26, 0x08, 0x8e);
-  set_idt_entry(27, (uint32_t)isr27, 0x08, 0x8e);
-  set_idt_entry(28, (uint32_t)isr28, 0x08, 0x8e);
-  set_idt_entry(29, (uint32_t)isr29, 0x08, 0x8e);
-  set_idt_entry(30, (uint32_t)isr30, 0x08, 0x8e);
-  set_idt_entry(31, (uint32_t)isr31, 0x08, 0x8e);
-  set_idt_entry(32, (uint32_t)irq0, 0x08, 0x8e);
-  set_idt_entry(33, (uint32_t)irq1, 0x08, 0x8e);
-  set_idt_entry(34, (uint32_t)irq2, 0x08, 0x8e);
-  set_idt_entry(35, (uint32_t)irq3, 0x08, 0x8e);
-  set_idt_entry(36, (uint32_t)irq4, 0x08, 0x8e);
-  set_idt_entry(37, (uint32_t)irq5, 0x08, 0x8e);
-  set_idt_entry(38, (uint32_t)irq6, 0x08, 0x8e);
-  set_idt_entry(39, (uint32_t)irq7, 0x08, 0x8e);
-  set_idt_entry(40, (uint32_t)irq8, 0x08, 0x8e);
-  set_idt_entry(41, (uint32_t)irq9, 0x08, 0x8e);
-  set_idt_entry(42, (uint32_t)irq10, 0x08, 0x8e);
-  set_idt_entry(43, (uint32_t)irq11, 0x08, 0x8e);
-  set_idt_entry(44, (uint32_t)irq12, 0x08, 0x8e);
-  set_idt_entry(45, (uint32_t)irq13, 0x08, 0x8e);
-  set_idt_entry(46, (uint32_t)irq14, 0x08, 0x8e);
-  set_idt_entry(47, (uint32_t)irq15, 0x08, 0x8e);
-  set_idt_entry(48, (uint32_t)isr48, 0x08, 0x8e);
-  set_idt_entry(49, (uint32_t)isr49, 0x08, 0x8e);
-  set_idt_entry(50, (uint32_t)isr50, 0x08, 0x8e);
-  set_idt_entry(51, (uint32_t)isr51, 0x08, 0x8e);
-  set_idt_entry(52, (uint32_t)isr52, 0x08, 0x8e);
-  set_idt_entry(53, (uint32_t)isr53, 0x08, 0x8e);
-  set_idt_entry(54, (uint32_t)isr54, 0x08, 0x8e);
-  set_idt_entry(55, (uint32_t)isr55, 0x08, 0x8e);
-  set_idt_entry(56, (uint32_t)isr56, 0x08, 0x8e);
-  set_idt_entry(57, (uint32_t)isr57, 0x08, 0x8e);
-  set_idt_entry(58, (uint32_t)isr58, 0x08, 0x8e);
-  set_idt_entry(59, (uint32_t)isr59, 0x08, 0x8e);
-  set_idt_entry(60, (uint32_t)isr60, 0x08, 0x8e);
-  set_idt_entry(61, (uint32_t)isr61, 0x08, 0x8e);
-  set_idt_entry(62, (uint32_t)isr62, 0x08, 0x8e);
-  set_idt_entry(63, (uint32_t)isr63, 0x08, 0x8e);
-  set_idt_entry(64, (uint32_t)isr64, 0x08, 0x8e);
-  set_idt_entry(65, (uint32_t)isr65, 0x08, 0x8e);
-  set_idt_entry(66, (uint32_t)isr66, 0x08, 0x8e);
-  set_idt_entry(67, (uint32_t)isr67, 0x08, 0x8e);
-  set_idt_entry(68, (uint32_t)isr68, 0x08, 0x8e);
-  set_idt_entry(69, (uint32_t)isr69, 0x08, 0x8e);
-  set_idt_entry(70, (uint32_t)isr70, 0x08, 0x8e);
-  set_idt_entry(71, (uint32_t)isr71, 0x08, 0x8e);
-  set_idt_entry(72, (uint32_t)isr72, 0x08, 0x8e);
-  set_idt_entry(73, (uint32_t)isr73, 0x08, 0x8e);
-  set_idt_entry(74, (uint32_t)isr74, 0x08, 0x8e);
-  set_idt_entry(75, (uint32_t)isr75, 0x08, 0x8e);
-  set_idt_entry(76, (uint32_t)isr76, 0x08, 0x8e);
-  set_idt_entry(77, (uint32_t)isr77, 0x08, 0x8e);
-  set_idt_entry(78, (uint32_t)isr78, 0x08, 0x8e);
-  set_idt_entry(79, (uint32_t)isr79, 0x08, 0x8e);
-  set_idt_entry(80, (uint32_t)isr80, 0x08, 0x8e);
-  set_idt_entry(81, (uint32_t)isr81, 0x08, 0x8e);
-  set_idt_entry(82, (uint32_t)isr82, 0x08, 0x8e);
-  set_idt_entry(83, (uint32_t)isr83, 0x08, 0x8e);
-  set_idt_entry(84, (uint32_t)isr84, 0x08, 0x8e);
-  set_idt_entry(85, (uint32_t)isr85, 0x08, 0x8e);
-  set_idt_entry(86, (uint32_t)isr86, 0x08, 0x8e);
-  set_idt_entry(87, (uint32_t)isr87, 0x08, 0x8e);
-  set_idt_entry(88, (uint32_t)isr88, 0x08, 0x8e);
-  set_idt_entry(89, (uint32_t)isr89, 0x08, 0x8e);
-  set_idt_entry(90, (uint32_t)isr90, 0x08, 0x8e);
-  set_idt_entry(91, (uint32_t)isr91, 0x08, 0x8e);
-  set_idt_entry(92, (uint32_t)isr92, 0x08, 0x8e);
-  set_idt_entry(93, (uint32_t)isr93, 0x08, 0x8e);
-  set_idt_entry(94, (uint32_t)isr94, 0x08, 0x8e);
-  set_idt_entry(95, (uint32_t)isr95, 0x08, 0x8e);
-  set_idt_entry(96, (uint32_t)isr96, 0x08, 0x8e);
-  set_idt_entry(97, (uint32_t)isr97, 0x08, 0x8e);
-  set_idt_entry(98, (uint32_t)isr98, 0x08, 0x8e);
-  set_idt_entry(99, (uint32_t)isr99, 0x08, 0x8e);
-  set_idt_entry(100, (uint32_t)isr100, 0x08, 0x8e);
-  set_idt_entry(101, (uint32_t)isr101, 0x08, 0x8e);
-  set_idt_entry(102, (uint32_t)isr102, 0x08, 0x8e);
-  set_idt_entry(103, (uint32_t)isr103, 0x08, 0x8e);
-  set_idt_entry(104, (uint32_t)isr104, 0x08, 0x8e);
-  set_idt_entry(105, (uint32_t)isr105, 0x08, 0x8e);
-  set_idt_entry(106, (uint32_t)isr106, 0x08, 0x8e);
-  set_idt_entry(107, (uint32_t)isr107, 0x08, 0x8e);
-  set_idt_entry(108, (uint32_t)isr108, 0x08, 0x8e);
-  set_idt_entry(109, (uint32_t)isr109, 0x08, 0x8e);
-  set_idt_entry(110, (uint32_t)isr110, 0x08, 0x8e);
-  set_idt_entry(111, (uint32_t)isr111, 0x08, 0x8e);
-  set_idt_entry(112, (uint32_t)isr112, 0x08, 0x8e);
-  set_idt_entry(113, (uint32_t)isr113, 0x08, 0x8e);
-  set_idt_entry(114, (uint32_t)isr114, 0x08, 0x8e);
-  set_idt_entry(115, (uint32_t)isr115, 0x08, 0x8e);
-  set_idt_entry(116, (uint32_t)isr116, 0x08, 0x8e);
-  set_idt_entry(117, (uint32_t)isr117, 0x08, 0x8e);
-  set_idt_entry(118, (uint32_t)isr118, 0x08, 0x8e);
-  set_idt_entry(119, (uint32_t)isr119, 0x08, 0x8e);
-  set_idt_entry(120, (uint32_t)isr120, 0x08, 0x8e);
-  set_idt_entry(121, (uint32_t)isr121, 0x08, 0x8e);
-  set_idt_entry(122, (uint32_t)isr122, 0x08, 0x8e);
-  set_idt_entry(123, (uint32_t)isr123, 0x08, 0x8e);
-  set_idt_entry(124, (uint32_t)isr124, 0x08, 0x8e);
-  set_idt_entry(125, (uint32_t)isr125, 0x08, 0x8e);
-  set_idt_entry(126, (uint32_t)isr126, 0x08, 0x8e);
-  set_idt_entry(127, (uint32_t)isr127, 0x08, 0x8e);
+  set_idt_entry(&idt_entries[0], (uint32_t)isr0, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[1], (uint32_t)isr1, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[2], (uint32_t)isr2, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[3], (uint32_t)isr3, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[4], (uint32_t)isr4, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[5], (uint32_t)isr5, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[6], (uint32_t)isr6, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[7], (uint32_t)isr7, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[8], (uint32_t)isr8, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[9], (uint32_t)isr9, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[10], (uint32_t)isr10, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[11], (uint32_t)isr11, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[12], (uint32_t)isr12, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[13], (uint32_t)isr13, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[14], (uint32_t)isr14, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[15], (uint32_t)isr15, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[16], (uint32_t)isr16, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[17], (uint32_t)isr17, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[18], (uint32_t)isr18, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[19], (uint32_t)isr19, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[20], (uint32_t)isr20, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[21], (uint32_t)isr21, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[22], (uint32_t)isr22, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[23], (uint32_t)isr23, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[24], (uint32_t)isr24, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[25], (uint32_t)isr25, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[26], (uint32_t)isr26, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[27], (uint32_t)isr27, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[28], (uint32_t)isr28, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[29], (uint32_t)isr29, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[30], (uint32_t)isr30, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[31], (uint32_t)isr31, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[IRQ0], (uint32_t)irq0, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[IRQ1], (uint32_t)irq1, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[IRQ2], (uint32_t)irq2, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[IRQ3], (uint32_t)irq3, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[IRQ4], (uint32_t)irq4, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[IRQ5], (uint32_t)irq5, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[IRQ6], (uint32_t)irq6, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[IRQ7], (uint32_t)irq7, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[IRQ8], (uint32_t)irq8, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[IRQ9], (uint32_t)irq9, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[IRQ10], (uint32_t)irq10, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[IRQ11], (uint32_t)irq11, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[IRQ12], (uint32_t)irq12, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[IRQ13], (uint32_t)irq13, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[IRQ14], (uint32_t)irq14, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[IRQ15], (uint32_t)irq15, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[48], (uint32_t)isr48, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[49], (uint32_t)isr49, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[50], (uint32_t)isr50, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[51], (uint32_t)isr51, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[52], (uint32_t)isr52, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[53], (uint32_t)isr53, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[54], (uint32_t)isr54, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[55], (uint32_t)isr55, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[56], (uint32_t)isr56, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[57], (uint32_t)isr57, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[58], (uint32_t)isr58, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[59], (uint32_t)isr59, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[60], (uint32_t)isr60, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[61], (uint32_t)isr61, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[62], (uint32_t)isr62, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[63], (uint32_t)isr63, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[64], (uint32_t)isr64, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[65], (uint32_t)isr65, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[66], (uint32_t)isr66, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[67], (uint32_t)isr67, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[68], (uint32_t)isr68, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[69], (uint32_t)isr69, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[70], (uint32_t)isr70, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[71], (uint32_t)isr71, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[72], (uint32_t)isr72, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[73], (uint32_t)isr73, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[74], (uint32_t)isr74, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[75], (uint32_t)isr75, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[76], (uint32_t)isr76, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[77], (uint32_t)isr77, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[78], (uint32_t)isr78, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[79], (uint32_t)isr79, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[80], (uint32_t)isr80, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[81], (uint32_t)isr81, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[82], (uint32_t)isr82, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[83], (uint32_t)isr83, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[84], (uint32_t)isr84, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[85], (uint32_t)isr85, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[86], (uint32_t)isr86, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[87], (uint32_t)isr87, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[88], (uint32_t)isr88, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[89], (uint32_t)isr89, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[90], (uint32_t)isr90, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[91], (uint32_t)isr91, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[92], (uint32_t)isr92, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[93], (uint32_t)isr93, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[94], (uint32_t)isr94, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[95], (uint32_t)isr95, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[96], (uint32_t)isr96, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[97], (uint32_t)isr97, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[98], (uint32_t)isr98, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[99], (uint32_t)isr99, KERNEL_CODE_SELECTOR, 0xf, 0,
+                DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[100], (uint32_t)isr100, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[101], (uint32_t)isr101, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[102], (uint32_t)isr102, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[103], (uint32_t)isr103, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[104], (uint32_t)isr104, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[105], (uint32_t)isr105, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[106], (uint32_t)isr106, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[107], (uint32_t)isr107, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[108], (uint32_t)isr108, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[109], (uint32_t)isr109, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[110], (uint32_t)isr110, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[111], (uint32_t)isr111, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[112], (uint32_t)isr112, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[113], (uint32_t)isr113, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[114], (uint32_t)isr114, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[115], (uint32_t)isr115, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[116], (uint32_t)isr116, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[117], (uint32_t)isr117, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[118], (uint32_t)isr118, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[119], (uint32_t)isr119, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[120], (uint32_t)isr120, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[121], (uint32_t)isr121, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[122], (uint32_t)isr122, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[123], (uint32_t)isr123, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[124], (uint32_t)isr124, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[125], (uint32_t)isr125, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[126], (uint32_t)isr126, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[127], (uint32_t)isr127, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
 
   // syscall
-  // TODO: please make all of this file clearer!
-  set_idt_entry(128, (uint32_t)isr128, 0x08, 0x8e | (0x3 << 5));
+  set_idt_entry(&idt_entries[128], (uint32_t)isr128, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_USER, 1);
 
-  set_idt_entry(129, (uint32_t)isr129, 0x08, 0x8e);
-  set_idt_entry(130, (uint32_t)isr130, 0x08, 0x8e);
-  set_idt_entry(131, (uint32_t)isr131, 0x08, 0x8e);
-  set_idt_entry(132, (uint32_t)isr132, 0x08, 0x8e);
-  set_idt_entry(133, (uint32_t)isr133, 0x08, 0x8e);
-  set_idt_entry(134, (uint32_t)isr134, 0x08, 0x8e);
-  set_idt_entry(135, (uint32_t)isr135, 0x08, 0x8e);
-  set_idt_entry(136, (uint32_t)isr136, 0x08, 0x8e);
-  set_idt_entry(137, (uint32_t)isr137, 0x08, 0x8e);
-  set_idt_entry(138, (uint32_t)isr138, 0x08, 0x8e);
-  set_idt_entry(139, (uint32_t)isr139, 0x08, 0x8e);
-  set_idt_entry(140, (uint32_t)isr140, 0x08, 0x8e);
-  set_idt_entry(141, (uint32_t)isr141, 0x08, 0x8e);
-  set_idt_entry(142, (uint32_t)isr142, 0x08, 0x8e);
-  set_idt_entry(143, (uint32_t)isr143, 0x08, 0x8e);
-  set_idt_entry(144, (uint32_t)isr144, 0x08, 0x8e);
-  set_idt_entry(145, (uint32_t)isr145, 0x08, 0x8e);
-  set_idt_entry(146, (uint32_t)isr146, 0x08, 0x8e);
-  set_idt_entry(147, (uint32_t)isr147, 0x08, 0x8e);
-  set_idt_entry(148, (uint32_t)isr148, 0x08, 0x8e);
-  set_idt_entry(149, (uint32_t)isr149, 0x08, 0x8e);
-  set_idt_entry(150, (uint32_t)isr150, 0x08, 0x8e);
-  set_idt_entry(151, (uint32_t)isr151, 0x08, 0x8e);
-  set_idt_entry(152, (uint32_t)isr152, 0x08, 0x8e);
-  set_idt_entry(153, (uint32_t)isr153, 0x08, 0x8e);
-  set_idt_entry(154, (uint32_t)isr154, 0x08, 0x8e);
-  set_idt_entry(155, (uint32_t)isr155, 0x08, 0x8e);
-  set_idt_entry(156, (uint32_t)isr156, 0x08, 0x8e);
-  set_idt_entry(157, (uint32_t)isr157, 0x08, 0x8e);
-  set_idt_entry(158, (uint32_t)isr158, 0x08, 0x8e);
-  set_idt_entry(159, (uint32_t)isr159, 0x08, 0x8e);
-  set_idt_entry(160, (uint32_t)isr160, 0x08, 0x8e);
-  set_idt_entry(161, (uint32_t)isr161, 0x08, 0x8e);
-  set_idt_entry(162, (uint32_t)isr162, 0x08, 0x8e);
-  set_idt_entry(163, (uint32_t)isr163, 0x08, 0x8e);
-  set_idt_entry(164, (uint32_t)isr164, 0x08, 0x8e);
-  set_idt_entry(165, (uint32_t)isr165, 0x08, 0x8e);
-  set_idt_entry(166, (uint32_t)isr166, 0x08, 0x8e);
-  set_idt_entry(167, (uint32_t)isr167, 0x08, 0x8e);
-  set_idt_entry(168, (uint32_t)isr168, 0x08, 0x8e);
-  set_idt_entry(169, (uint32_t)isr169, 0x08, 0x8e);
-  set_idt_entry(170, (uint32_t)isr170, 0x08, 0x8e);
-  set_idt_entry(171, (uint32_t)isr171, 0x08, 0x8e);
-  set_idt_entry(172, (uint32_t)isr172, 0x08, 0x8e);
-  set_idt_entry(173, (uint32_t)isr173, 0x08, 0x8e);
-  set_idt_entry(174, (uint32_t)isr174, 0x08, 0x8e);
-  set_idt_entry(175, (uint32_t)isr175, 0x08, 0x8e);
-  set_idt_entry(176, (uint32_t)isr176, 0x08, 0x8e);
-  set_idt_entry(177, (uint32_t)isr177, 0x08, 0x8e);
-  set_idt_entry(178, (uint32_t)isr178, 0x08, 0x8e);
-  set_idt_entry(179, (uint32_t)isr179, 0x08, 0x8e);
-  set_idt_entry(180, (uint32_t)isr180, 0x08, 0x8e);
-  set_idt_entry(181, (uint32_t)isr181, 0x08, 0x8e);
-  set_idt_entry(182, (uint32_t)isr182, 0x08, 0x8e);
-  set_idt_entry(183, (uint32_t)isr183, 0x08, 0x8e);
-  set_idt_entry(184, (uint32_t)isr184, 0x08, 0x8e);
-  set_idt_entry(185, (uint32_t)isr185, 0x08, 0x8e);
-  set_idt_entry(186, (uint32_t)isr186, 0x08, 0x8e);
-  set_idt_entry(187, (uint32_t)isr187, 0x08, 0x8e);
-  set_idt_entry(188, (uint32_t)isr188, 0x08, 0x8e);
-  set_idt_entry(189, (uint32_t)isr189, 0x08, 0x8e);
-  set_idt_entry(190, (uint32_t)isr190, 0x08, 0x8e);
-  set_idt_entry(191, (uint32_t)isr191, 0x08, 0x8e);
-  set_idt_entry(192, (uint32_t)isr192, 0x08, 0x8e);
-  set_idt_entry(193, (uint32_t)isr193, 0x08, 0x8e);
-  set_idt_entry(194, (uint32_t)isr194, 0x08, 0x8e);
-  set_idt_entry(195, (uint32_t)isr195, 0x08, 0x8e);
-  set_idt_entry(196, (uint32_t)isr196, 0x08, 0x8e);
-  set_idt_entry(197, (uint32_t)isr197, 0x08, 0x8e);
-  set_idt_entry(198, (uint32_t)isr198, 0x08, 0x8e);
-  set_idt_entry(199, (uint32_t)isr199, 0x08, 0x8e);
-  set_idt_entry(200, (uint32_t)isr200, 0x08, 0x8e);
-  set_idt_entry(201, (uint32_t)isr201, 0x08, 0x8e);
-  set_idt_entry(202, (uint32_t)isr202, 0x08, 0x8e);
-  set_idt_entry(203, (uint32_t)isr203, 0x08, 0x8e);
-  set_idt_entry(204, (uint32_t)isr204, 0x08, 0x8e);
-  set_idt_entry(205, (uint32_t)isr205, 0x08, 0x8e);
-  set_idt_entry(206, (uint32_t)isr206, 0x08, 0x8e);
-  set_idt_entry(207, (uint32_t)isr207, 0x08, 0x8e);
-  set_idt_entry(208, (uint32_t)isr208, 0x08, 0x8e);
-  set_idt_entry(209, (uint32_t)isr209, 0x08, 0x8e);
-  set_idt_entry(210, (uint32_t)isr210, 0x08, 0x8e);
-  set_idt_entry(211, (uint32_t)isr211, 0x08, 0x8e);
-  set_idt_entry(212, (uint32_t)isr212, 0x08, 0x8e);
-  set_idt_entry(213, (uint32_t)isr213, 0x08, 0x8e);
-  set_idt_entry(214, (uint32_t)isr214, 0x08, 0x8e);
-  set_idt_entry(215, (uint32_t)isr215, 0x08, 0x8e);
-  set_idt_entry(216, (uint32_t)isr216, 0x08, 0x8e);
-  set_idt_entry(217, (uint32_t)isr217, 0x08, 0x8e);
-  set_idt_entry(218, (uint32_t)isr218, 0x08, 0x8e);
-  set_idt_entry(219, (uint32_t)isr219, 0x08, 0x8e);
-  set_idt_entry(220, (uint32_t)isr220, 0x08, 0x8e);
-  set_idt_entry(221, (uint32_t)isr221, 0x08, 0x8e);
-  set_idt_entry(222, (uint32_t)isr222, 0x08, 0x8e);
-  set_idt_entry(223, (uint32_t)isr223, 0x08, 0x8e);
-  set_idt_entry(224, (uint32_t)isr224, 0x08, 0x8e);
-  set_idt_entry(225, (uint32_t)isr225, 0x08, 0x8e);
-  set_idt_entry(226, (uint32_t)isr226, 0x08, 0x8e);
-  set_idt_entry(227, (uint32_t)isr227, 0x08, 0x8e);
-  set_idt_entry(228, (uint32_t)isr228, 0x08, 0x8e);
-  set_idt_entry(229, (uint32_t)isr229, 0x08, 0x8e);
-  set_idt_entry(230, (uint32_t)isr230, 0x08, 0x8e);
-  set_idt_entry(231, (uint32_t)isr231, 0x08, 0x8e);
-  set_idt_entry(232, (uint32_t)isr232, 0x08, 0x8e);
-  set_idt_entry(233, (uint32_t)isr233, 0x08, 0x8e);
-  set_idt_entry(234, (uint32_t)isr234, 0x08, 0x8e);
-  set_idt_entry(235, (uint32_t)isr235, 0x08, 0x8e);
-  set_idt_entry(236, (uint32_t)isr236, 0x08, 0x8e);
-  set_idt_entry(237, (uint32_t)isr237, 0x08, 0x8e);
-  set_idt_entry(238, (uint32_t)isr238, 0x08, 0x8e);
-  set_idt_entry(239, (uint32_t)isr239, 0x08, 0x8e);
-  set_idt_entry(240, (uint32_t)isr240, 0x08, 0x8e);
-  set_idt_entry(241, (uint32_t)isr241, 0x08, 0x8e);
-  set_idt_entry(242, (uint32_t)isr242, 0x08, 0x8e);
-  set_idt_entry(243, (uint32_t)isr243, 0x08, 0x8e);
-  set_idt_entry(244, (uint32_t)isr244, 0x08, 0x8e);
-  set_idt_entry(245, (uint32_t)isr245, 0x08, 0x8e);
-  set_idt_entry(246, (uint32_t)isr246, 0x08, 0x8e);
-  set_idt_entry(247, (uint32_t)isr247, 0x08, 0x8e);
-  set_idt_entry(248, (uint32_t)isr248, 0x08, 0x8e);
-  set_idt_entry(249, (uint32_t)isr249, 0x08, 0x8e);
-  set_idt_entry(250, (uint32_t)isr250, 0x08, 0x8e);
-  set_idt_entry(251, (uint32_t)isr251, 0x08, 0x8e);
-  set_idt_entry(252, (uint32_t)isr252, 0x08, 0x8e);
-  set_idt_entry(253, (uint32_t)isr253, 0x08, 0x8e);
-  set_idt_entry(254, (uint32_t)isr254, 0x08, 0x8e);
-  set_idt_entry(255, (uint32_t)isr255, 0x08, 0x8e);
+  set_idt_entry(&idt_entries[129], (uint32_t)isr129, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[130], (uint32_t)isr130, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[131], (uint32_t)isr131, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[132], (uint32_t)isr132, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[133], (uint32_t)isr133, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[134], (uint32_t)isr134, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[135], (uint32_t)isr135, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[136], (uint32_t)isr136, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[137], (uint32_t)isr137, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[138], (uint32_t)isr138, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[139], (uint32_t)isr139, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[140], (uint32_t)isr140, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[141], (uint32_t)isr141, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[142], (uint32_t)isr142, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[143], (uint32_t)isr143, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[144], (uint32_t)isr144, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[145], (uint32_t)isr145, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[146], (uint32_t)isr146, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[147], (uint32_t)isr147, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[148], (uint32_t)isr148, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[149], (uint32_t)isr149, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[150], (uint32_t)isr150, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[151], (uint32_t)isr151, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[152], (uint32_t)isr152, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[153], (uint32_t)isr153, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[154], (uint32_t)isr154, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[155], (uint32_t)isr155, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[156], (uint32_t)isr156, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[157], (uint32_t)isr157, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[158], (uint32_t)isr158, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[159], (uint32_t)isr159, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[160], (uint32_t)isr160, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[161], (uint32_t)isr161, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[162], (uint32_t)isr162, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[163], (uint32_t)isr163, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[164], (uint32_t)isr164, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[165], (uint32_t)isr165, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[166], (uint32_t)isr166, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[167], (uint32_t)isr167, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[168], (uint32_t)isr168, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[169], (uint32_t)isr169, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[170], (uint32_t)isr170, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[171], (uint32_t)isr171, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[172], (uint32_t)isr172, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[173], (uint32_t)isr173, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[174], (uint32_t)isr174, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[175], (uint32_t)isr175, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[176], (uint32_t)isr176, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[177], (uint32_t)isr177, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[178], (uint32_t)isr178, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[179], (uint32_t)isr179, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[180], (uint32_t)isr180, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[181], (uint32_t)isr181, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[182], (uint32_t)isr182, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[183], (uint32_t)isr183, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[184], (uint32_t)isr184, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[185], (uint32_t)isr185, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[186], (uint32_t)isr186, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[187], (uint32_t)isr187, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[188], (uint32_t)isr188, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[189], (uint32_t)isr189, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[190], (uint32_t)isr190, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[191], (uint32_t)isr191, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[192], (uint32_t)isr192, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[193], (uint32_t)isr193, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[194], (uint32_t)isr194, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[195], (uint32_t)isr195, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[196], (uint32_t)isr196, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[197], (uint32_t)isr197, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[198], (uint32_t)isr198, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[199], (uint32_t)isr199, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[200], (uint32_t)isr200, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[201], (uint32_t)isr201, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[202], (uint32_t)isr202, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[203], (uint32_t)isr203, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[204], (uint32_t)isr204, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[205], (uint32_t)isr205, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[206], (uint32_t)isr206, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[207], (uint32_t)isr207, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[208], (uint32_t)isr208, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[209], (uint32_t)isr209, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[210], (uint32_t)isr210, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[211], (uint32_t)isr211, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[212], (uint32_t)isr212, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[213], (uint32_t)isr213, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[214], (uint32_t)isr214, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[215], (uint32_t)isr215, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[216], (uint32_t)isr216, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[217], (uint32_t)isr217, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[218], (uint32_t)isr218, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[219], (uint32_t)isr219, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[220], (uint32_t)isr220, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[221], (uint32_t)isr221, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[222], (uint32_t)isr222, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[223], (uint32_t)isr223, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[224], (uint32_t)isr224, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[225], (uint32_t)isr225, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[226], (uint32_t)isr226, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[227], (uint32_t)isr227, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[228], (uint32_t)isr228, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[229], (uint32_t)isr229, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[230], (uint32_t)isr230, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[231], (uint32_t)isr231, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[232], (uint32_t)isr232, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[233], (uint32_t)isr233, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[234], (uint32_t)isr234, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[235], (uint32_t)isr235, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[236], (uint32_t)isr236, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[237], (uint32_t)isr237, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[238], (uint32_t)isr238, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[239], (uint32_t)isr239, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[240], (uint32_t)isr240, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[241], (uint32_t)isr241, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[242], (uint32_t)isr242, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[243], (uint32_t)isr243, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[244], (uint32_t)isr244, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[245], (uint32_t)isr245, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[246], (uint32_t)isr246, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[247], (uint32_t)isr247, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[248], (uint32_t)isr248, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[249], (uint32_t)isr249, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[250], (uint32_t)isr250, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[251], (uint32_t)isr251, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[252], (uint32_t)isr252, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[253], (uint32_t)isr253, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[254], (uint32_t)isr254, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
+  set_idt_entry(&idt_entries[255], (uint32_t)isr255, KERNEL_CODE_SELECTOR, 0xf,
+                0, DPL_KERNEL, 1);
 
   // write the idt to the cpu
   idt_write((uint32_t)&ptr_to_idt);


### PR DESCRIPTION
Cleanup of arch/i386/descriptors.c to make the code much more readable and easier to understand.